### PR TITLE
Support type="search" for the filterText field

### DIFF
--- a/exercises/spec_5.js
+++ b/exercises/spec_5.js
@@ -9,7 +9,7 @@ describe('Inverse dataflow', function() {
         var _comp = render(function() {
             ReactTestUtils.scryRenderedDOMComponentsWithTag(_comp, 'input').forEach(function(_input) {
                 var node = _input.getDOMNode()
-                if (node.type == 'text')     node.value   = 'test'
+                if (node.type !== 'checkbox')     node.value   = 'test'
                 if (node.type == 'checkbox') node.checked = true
                 ReactTestUtils.Simulate.change(_input)
             })
@@ -17,7 +17,7 @@ describe('Inverse dataflow', function() {
                 var _filterableProductTable = ReactTestUtils.findRenderedComponentWithType(_comp, Solution.FilterableProductTable)
                 assert(_filterableProductTable.state.filterText  == 'test')
                 assert(_filterableProductTable.state.inStockOnly == true)
-                done()                
+                done()
             })
         })
     })


### PR DESCRIPTION
Hi there

That's quite a small change. I got quite confused when doing the exercises because the tests are relying on the fact that the filtering field is of input type `text`. I had set it to type `search` because it seemed more appropriate.

Cheers!