### PR TITLE
Use ref callbacks rather than refs as strings (now deprecated) in exa…

### DIFF
--- a/exercises/step_5__add_inverse_data_flow/solution/solution.js
+++ b/exercises/step_5__add_inverse_data_flow/solution/solution.js
@@ -75,8 +75,8 @@ export const ProductTable = React.createClass({
 
 export const SearchBar = React.createClass({
     handleChange() {
-        const filterText = ReactDOM.findDOMNode(this.refs.filterText).value;
-        const inStockOnly = ReactDOM.findDOMNode(this.refs.inStockOnly).checked;
+        const filterText = this.filterText.value;
+        const inStockOnly = this.inStockOnly.checked;
 
         this.props.onUserInput(filterText, inStockOnly);
     },
@@ -87,7 +87,7 @@ export const SearchBar = React.createClass({
         return (
             <form>
                 <input
-                    ref="filterText"
+                    ref={(r) => this.filterText = r}
                     type="search"
                     placeholder="Search..."
                     value={filterText}
@@ -95,7 +95,7 @@ export const SearchBar = React.createClass({
                 />
                 <label>
                     <input
-                        ref="inStockOnly"
+                        ref={(r) => this.inStockOnly = r}
                         type="checkbox"
                         checked={inStockOnly}
                         onChange={this.handleChange}


### PR DESCRIPTION
…mple solution

When trying to complete the final part of the workshopper I noticed on the React documentation that string refs have now been deprecated, in favour of callback refs. The React documentation doesn't even mention string callbacks anymore: https://facebook.github.io/react/docs/refs-and-the-dom.html