### PR TITLE
Update spec_4.js

### DIFF
--- a/exercises/spec_4.js
+++ b/exercises/spec_4.js
@@ -13,8 +13,8 @@ describe('Stateful', function() {
     it('state should live at FilterableProductTable', function(done) {
         var _comp = render(function() {
             var _filterableProductTable = ReactTestUtils.findRenderedComponentWithType(_comp, Solution.FilterableProductTable)
-            assert(_filterableProductTable.state.filterText != undefined)
-            assert(_filterableProductTable.state.inStockOnly != undefined)
+            assert(_filterableProductTable.state.filterText !== undefined)
+            assert(_filterableProductTable.state.inStockOnly !== undefined)
             done()
         })
     })


### PR DESCRIPTION
Strict unequality is needed since the initial `filterText` value can be `null` which makes this test fail (since `null == undefined`)